### PR TITLE
Update README.md when we are forwarding to lo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,21 +77,36 @@ the response packets to the default route (internet). To work around
 we deploy a custom routing table, which forces the return traffic to
 be routed to loopback.
 
-This routing magic is required:
+1) if traffic is forwarded to lo interface (127.0.0.1 / ::1 for exemple)
+    # 1. Route packets from lo address and lo interface to table 100
+    ip -4 rule add from 127.0.0.1/8 iif lo table 100
+    ip -6 rule add from ::1/128 iif lo table 100
 
-    # 1. Save conntrack CONNMARK on packets sent with MARK 123.
+    # 2. In routing table=100 treat all IP addresses as bound to
+    # loopback, and pass them to network stack for processing:
+    ip route add local 0.0.0.0/0 dev lo table 100
+    ip -6 route add local ::/0 dev lo table 100
+
+2) if traffic is forwarded to any other interface
+    # 1. Check if you have a default route for ipv4 / ipv6
+    # if you don't have any default route response will be dropped before #4 & #5
+
+    # 2. Enable route_localnet on your default interface
+    echo 1 > /proc/sys/net/ipv4/conf/eth0/route_localnet
+
+    # 3. Save conntrack CONNMARK on packets sent with MARK 123.
     iptables -t mangle -I PREROUTING -m mark --mark 123 -m comment --comment mmproxy -j CONNMARK --save-mark
     ip6tables -t mangle -I PREROUTING -m mark --mark 123 -m comment --comment mmproxy -j CONNMARK --save-mark
 
-    # 2. Restore MARK on packets belonging to connections with conntrack CONNMARK 123.
+    # 4. Restore MARK on packets belonging to connections with conntrack CONNMARK 123.
     iptables -t mangle -I OUTPUT -m connmark --mark 123 -m comment --comment mmproxy -j CONNMARK --restore-mark
     ip6tables -t mangle -I OUTPUT -m connmark --mark 123 -m comment --comment mmproxy -j CONNMARK --restore-mark
 
-    # 3. Route packets with MARK 123 to routing table 100
+    # 5. Route packets with MARK 123 to routing table 100
     ip rule add fwmark 123 lookup 100
     ip -6 rule add fwmark 123 lookup 100
 
-    # 4. In routing table=100 treat all IP addresses as bound to
+    # 6. In routing table=100 treat all IP addresses as bound to
     # loopback, and pass them to network stack for processing:
     ip route add local 0.0.0.0/0 dev lo table 100
     ip -6 route add local ::/0 dev lo table 100


### PR DESCRIPTION
When forwarding to lo interface address, we can simplify the configuration
(1 ip rule and 1 ip route per ip version)
Current approach (using CONNMARK) is required if we forward traffic to
interfaces other than lo

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>