### PR TITLE
Correct memory leaks

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -124,6 +124,8 @@ coroutine void new_connection(int cd, struct state *state)
 		goto parseerror;
 	}
 
+	free(words);
+
 	char rstr[IPADDR_MAXSTRLEN + 7];
 	ipaddrstr_port(remote_addr, rstr);
 
@@ -159,6 +161,7 @@ coroutine void new_connection(int cd, struct state *state)
 	do_proxy_half_duplex(rs, cd, ch);
 	err = chr(ch, int);
 	chr(ch, int);
+	free(ch);
 
 disconnected:
 	fdclean(cd);
@@ -188,6 +191,7 @@ void do_accept(tcpsock sd, struct state *state)
 		}
 
 		go(new_connection(tcpsock_fd(cd), state));
+		free(cd);
 	}
 }
 


### PR DESCRIPTION
Please consider this pull request to free memory currently left allocated. Memory leaks may occur over time in the `do_accept` and `new_connection` functions.

The scenario tested to produce the problem is using mmproxy in front of OpenSSH. Without the changes, this script loop will cause growing heap utilization due to the leak. 

```bash
for i in {1..10000}; do 
  echo -en "PROXY TCP4 0.0.0.0 0.0.0.0 0 0\r\nSSH-2.0-" | nc -W1 localhost 2222 > /dev/null; 
done
```